### PR TITLE
Fix Botania Mana Pool render issues

### DIFF
--- a/config/botania-client.toml
+++ b/config/botania-client.toml
@@ -9,7 +9,7 @@ splashes = true
 
 [rendering]
 	#Set this to false to disable the use of shaders for some of the mod's renders. (Requires game restart)
-	shaders = true
+	shaders = false
 	#Set this to false to disable the wireframe when looking a block bound to something (spreaders, flowers, etc).
 	boundBlockWireframe = true
 	#Set this to false to disable rendering of accessories in the player.


### PR DESCRIPTION
Changed shaders to false to fix Shaders

This will fix an issue with Oculus Shaders not showing anything in the mana pool.
This is just a visual change through the config file for the next update

More PR coming soon!